### PR TITLE
chore: Node.jsのバージョンを18から22へ変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "printWidth": 100
   },
   "engines": {
-    "node": ">=18.x"
+    "node": ">=22.x"
   },
   "dependencies": {
     "@types/node": "^22.13.11",


### PR DESCRIPTION
2025/9/1にNode.js v18でのビルド・ランタイムのサポートが終了するため、18→22に変更しました。
https://vercel.com/changelog/node-js-18-is-being-deprecated