### PR TITLE
PlaywrightでE2Eテストを追加

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,6 +22,9 @@ jobs:
       run: npx playwright install --with-deps
     - name: Run Playwright tests
       run: npm run test:e2e
+      env:
+        MICROCMS_API_KEY: ${{ secrets.MICROCMS_API_KEY }}
+        MICROCMS_SERVICE_DOMAIN: ${{ secrets.MICROCMS_SERVICE_DOMAIN }}
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,0 +1,30 @@
+name: Playwright Tests
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps
+    - name: Run Playwright tests
+      run: npm run test:e2e
+    - uses: actions/upload-artifact@v4
+      if: ${{ !cancelled() }}
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+playwright-report
+test-results

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ microCMS 管理画面の URL（https://xxxxxxxx.microcms.io）の xxxxxxxx の�
 開発環境 → http://localhost:3000  
 本番環境 → https://xxxxxxxx.vercel.app/ など
 
+### GitHub Actionsへの環境変数の設定
+
+このリポジトリではPlaywrightによるE2Eテストが実装されています。
+GitHubに変更をプッシュする、あるいはPull Requestを作成すると自動でテストが実行されます。
+
+利用するにはGitHub Actionsのシークレットへの設定が必要です。
+[こちらの手順](https://docs.github.com/ja/actions/how-tos/write-workflows/choose-what-workflows-do/use-secrets)に従って、`MICROCMS_API_KEY`と`MICROCMS_SERVICE_DOMAIN`をシークレットに設定してください。
+
+
 ## 開発の仕方
 
 1. パッケージのインストール

--- a/e2e/article-detail.spec.ts
+++ b/e2e/article-detail.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('記事詳細ページ', () => {
+  let articleUrl: string;
+
+  test.beforeEach(async ({ page }) => {
+    // まず記事一覧ページに行き、最初の記事のURLを取得
+    await page.goto('/');
+    const firstArticleLink = page.locator('a[href*="/articles/"]').first();
+    await expect(firstArticleLink).toBeVisible();
+    articleUrl = await firstArticleLink.getAttribute('href') || '/articles/test';
+  });
+
+  test('記事詳細ページが正しく表示される', async ({ page }) => {
+    await page.goto(articleUrl);
+
+    // ページが正常に読み込まれることを確認
+    await expect(page).not.toHaveTitle('404');
+
+    // 記事のコンテンツが存在することを確認（最初に見つかった要素のみ）
+    const articleContent = page.locator('article').or(
+      page.locator('[data-testid="article-content"]')
+    ).or(
+      page.locator('main')
+    ).first();
+    
+    await expect(articleContent).toBeVisible();
+  });
+
+  test('記事タイトルが表示される', async ({ page }) => {
+    await page.goto(articleUrl);
+
+    // H1タグまたはタイトルが表示されることを確認（最初に見つかった要素のみ）
+    const title = page.locator('h1').or(
+      page.locator('[data-testid="article-title"]')
+    ).first();
+    
+    await expect(title).toBeVisible();
+    await expect(title).not.toBeEmpty();
+  });
+
+  test('記事の日付が表示される', async ({ page }) => {
+    await page.goto(articleUrl);
+
+    // 日付要素が存在することを確認
+    const dateElement = page.locator('[data-testid="article-date"]').or(
+      page.locator('time')
+    ).or(
+      page.locator('*').filter({ hasText: /\d{4}[-/]\d{1,2}[-/]\d{1,2}/ }).first()
+    );
+    
+    // 日付が存在する場合のみテスト
+    const dateCount = await dateElement.count();
+    if (dateCount > 0) {
+      await expect(dateElement.first()).toBeVisible();
+    }
+  });
+
+  test('記事の本文が表示される', async ({ page }) => {
+    await page.goto(articleUrl);
+
+    // 記事本文のコンテンツが存在することを確認
+    const content = page.locator('div').filter({ hasText: /\w+/ }).first();
+    
+    await expect(content).toBeVisible();
+  });
+
+  test('ホームページに戻るナビゲーションが機能する', async ({ page }) => {
+    await page.goto(articleUrl);
+
+    // ホームページリンクまたはロゴをクリック
+    const homeLink = page.locator('a[href="/"]').or(
+      page.locator('[data-testid="home-link"]')
+    ).first();
+    
+    // ホームリンクが存在する場合のみテスト
+    const homeLinkCount = await homeLink.count();
+    if (homeLinkCount > 0) {
+      await homeLink.click();
+      await expect(page).toHaveURL('/');
+    }
+  });
+});

--- a/e2e/articles-list.spec.ts
+++ b/e2e/articles-list.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('記事一覧ページ', () => {
+  test('記事一覧ページが正しく表示される', async ({ page }) => {
+    await page.goto('/');
+
+    // ページタイトルが存在することを確認
+    await expect(page).toHaveTitle(/Blog/);
+
+    // 記事リストが表示されることを確認
+    const articleList = page.locator('[data-testid="article-list"]').or(
+      page.locator('article').first()
+    ).or(
+      page.locator('a[href*="/articles/"]').first()
+    );
+    
+    // 記事が存在するか確認
+    await expect(articleList).toBeVisible();
+  });
+
+  test('記事リンクをクリックして詳細ページに遷移できる', async ({ page }) => {
+    await page.goto('/');
+
+    // 最初の記事リンクを取得してクリック
+    const firstArticleLink = page.locator('a[href*="/articles/"]').first();
+    await expect(firstArticleLink).toBeVisible();
+    
+    const href = await firstArticleLink.getAttribute('href');
+    await firstArticleLink.click();
+
+    // 記事詳細ページに遷移したことを確認
+    await expect(page).toHaveURL(new RegExp(href!));
+  });
+
+  test('ページネーションが表示される（記事が多い場合）', async ({ page }) => {
+    await page.goto('/');
+
+    // ページネーションが存在するかチェック（存在しない場合はスキップ）
+    const pagination = page.locator('[data-testid="pagination"]').or(
+      page.locator('nav').or(
+        page.locator('a[href*="/p/"]')
+      )
+    );
+    
+    const paginationCount = await pagination.count();
+    if (paginationCount > 0) {
+      await expect(pagination.first()).toBeVisible();
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "react-dom": "^19.0.0",
         "typescript": "^5.8.2"
       },
+      "devDependencies": {
+        "@playwright/test": "^1.54.2"
+      },
       "engines": {
         "node": ">=22.x"
       }
@@ -774,6 +777,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -2628,6 +2647,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -3933,6 +3967,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'"
+    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "prettier": {
     "trailingComma": "all",
@@ -37,5 +39,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^5.8.2"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.54.2"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
+});


### PR DESCRIPTION
- Playwrightをdevdependencyとして追加
- 記事一覧ページと記事詳細ページのE2Eテストを実装
- GitHub ActionsでPR時に自動テスト実行するワークフローを追加
- npm scriptsでtest:e2eとtest:e2e:uiコマンドを追加
