### PR TITLE
chore: @types/reactと@types/react-domのバージョンを更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/node": "^24.1.0",
-        "@types/react": "^19.0.12",
-        "@types/react-dom": "^19.0.4",
+        "@types/react": "^19.2.10",
+        "@types/react-dom": "^19.2.3",
         "cheerio": "^1.0.0-rc.12",
         "date-fns-tz": "^3.2.0",
         "encoding": "^0.1.13",
@@ -2654,6 +2654,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "dependencies": {
     "@types/node": "^24.1.0",
-    "@types/react": "^19.0.12",
-    "@types/react-dom": "^19.0.4",
+    "@types/react": "^19.2.10",
+    "@types/react-dom": "^19.2.3",
     "cheerio": "^1.0.0-rc.12",
     "date-fns-tz": "^3.2.0",
     "encoding": "^0.1.13",


### PR DESCRIPTION
#42 に伴う対応