### PR TITLE
ユーザー定義 API の型定義の修正

### DIFF
--- a/components/Article/index.tsx
+++ b/components/Article/index.tsx
@@ -56,9 +56,9 @@ export default function Article({ data }: Props) {
       </picture>
       <div
         className={styles.content}
-        dangerouslySetInnerHTML={{
+        dangerouslySetInnerHTML={data.content ? {
           __html: `${formatRichText(data.content)}`,
-        }}
+        } : undefined}
       />
       <Profile writer={data.writer} />
     </main>

--- a/components/Profile/index.tsx
+++ b/components/Profile/index.tsx
@@ -2,7 +2,7 @@ import styles from './index.module.css';
 import { Writer } from '@/libs/microcms';
 
 type Props = {
-  writer?: Writer;
+  writer?: Writer | null;
 };
 
 export default function Profile({ writer }: Props) {

--- a/libs/microcms.ts
+++ b/libs/microcms.ts
@@ -9,26 +9,26 @@ import { notFound } from 'next/navigation';
 
 // タグの型定義
 export type Tag = {
-  name: string;
+  name?: string;
 } & MicroCMSContentId &
   MicroCMSDate;
 
 // ライターの型定義
 export type Writer = {
-  name: string;
-  profile: string;
+  name?: string;
+  profile?: string;
   image?: MicroCMSImage;
 } & MicroCMSContentId &
   MicroCMSDate;
 
 // ブログの型定義
 export type Blog = {
-  title: string;
-  description: string;
-  content: string;
+  title?: string;
+  description?: string;
+  content?: string;
   thumbnail?: MicroCMSImage;
-  tags?: Tag[];
-  writer?: Writer;
+  tags: Tag[];
+  writer: Writer | null;
 };
 
 export type Article = Blog & MicroCMSContentId & MicroCMSDate;


### PR DESCRIPTION
はじめまして。こちらの「シンプルなブログ」テンプレートを利用させていただいたところ、不具合があったため修正プルリクエストを出させていただきました。

---

テンプレート内で定義されている、このテンプレートで作られるコンテンツ（API）のレスポンスの型が、実際の microCMS API のレスポンスと合っておらず、それによって記事詳細画面 (SSR) で以下の実行時エラーが発生することがあります。

```
 ⨯ Error: cheerio.load() expects a string
    at formatRichText (libs/utils.ts:11:17)
    at Article (components/Article/index.tsx:60:36)

   9 |
  10 | export const formatRichText = (richText: string) => {
> 11 |   const $ = load(richText, null, false);
     |                 ^
  12 |   const highlight = (text: string, lang?: string) => {
  13 |     if (!lang) return hljs.highlightAuto(text);
  14 |     try { {
```

> [!NOTE]
> このときの `richText` の実際の値は `undefined` です。

このテンプレートで作られる `blog` コンテンツの `content` （本文）はオプショナルです。`blog` エントリーの登録において `content` を空にした場合は、[GET APIのフィールドごとのレスポンス形式｜microCMSドキュメント](https://document.microcms.io/content-api/get-api-field-responses#hf57c580171)の「フィールドが空値の場合のレスポンス一覧」で示されているとおり、レスポンスにおいて `content` フィールドがキーごと省略されるため、 `formatRichText` の `richText` には `string` ではなく `undefined` が渡され、最終的に実行時エラーが発生します。

> [!TIP]
> なお、もし `content` が必須になっていたとしても、下書き保存では値を省略可能でレスポンスもキーなしとなるため、（その場合も）この対応は必要かと思います。

その他、「フィールドが空値の場合のレスポンス一覧」にもとづき、 `Blog`, `Writer`, `Tag` について、microCMS 側での実際のコンテンツ定義に対してコード側の型が合っていないフィールドをすべて修正しました。
